### PR TITLE
Makefile: Fix quoting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -719,7 +719,7 @@ ifneq ($(HG),)
 	$(_E)
 endif
 	$(_E) "Release:"
-	$(_E) "bananas:     Upload bundle to BaNaNaS
+	$(_E) "bananas:     Upload bundle to BaNaNaS"
 	$(_E)
 	$(_E) "Valid command line variables are:"
 	$(_E) "Helper programmes:"


### PR DESCRIPTION
Calling `make -j1 GIMP= help` results in:

```
Release:
/bin/bash: -c: line 0: unexpected EOF while looking for matching `"'
/bin/bash: -c: line 1: syntax error: unexpected end of file
make: *** [Makefile:706: help] Error 1
```

This is broken since commit b10f57e39342af34209c349ed514d61f10b56386