### PR TITLE
Fix: [Makefile] make sure 'make clean' cleans all generated files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ SCRIPT_DIR          ?= scripts
 # Define the filenames of the grf and nml file. They must be in the main directoy
 GRF_FILES            ?= $(addsuffix .grf,$(BASE_FILENAME))
 NML_FILES            ?= $(addsuffix .nml,$(BASE_FILENAME))
+DEP_FILES            ?= $(addsuffix .grf.dep,$(BASE_FILENAME)) $(addsuffix .nml.dep,$(BASE_FILENAME))
 PNML_FILES           ?= $(addsuffix .pnml,$(BASE_FILENAME))
 DOC_FILES            ?= $(LICENSE_FILE) $(CHANGELOG_FILE) $(README_FILE)
 LNG_FILES            ?= lang/*.lng
@@ -73,7 +74,7 @@ all: bundle_tar
 
 FORCE:
 
--include *.dep
+-include $(DEP_FILES)
 
 
 ################################################################
@@ -187,6 +188,13 @@ Makefile.vcs: FORCE
 distclean:: clean
 maintainer-clean:: distclean
 
+clean::
+	$(_E) "[CLEAN DEP]"
+	$(_V)-rm -rf $(DEP_FILES)
+
+clean::
+	$(_E) "[CLEAN VCS]"
+	$(_V)-rm -f Makefile.vcs
 
 ################################################################
 #
@@ -326,6 +334,7 @@ clean::
 	$(_V)-rm -rf $(GRF_FILES).cache
 	$(_V)-rm -rf $(GRF_FILES).cacheindex
 	$(_V)-rm -rf .nmlcache
+	$(_V)-rm -rf custom_tags.txt
 
 maintainer-clean::
 	$(_E) "[MAINTAINER-CLEAN GRF]"


### PR DESCRIPTION
.dep files were left behind, as some other files were. Normally
this would be fine, but there are cases where the generated .dep
content is invalid. After that, normal users get stuck, as
'make clean' doesn't bring them back to a known-good-state.

Now 'make clean' removes all generated files correctly, meaning
the repository should be back to a known-good-state afterwards.