### PR TITLE
Fix: [Makefile] tell the user he needs to install grfcodec if grfid is not found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ ifdef PNML_FILES
 endif
 
 # GRF tools
-GRFID          ?= grfid
+GRFID          ?= $(shell which grfid)
 GRFID_FLAGS    ?= -m
 MUSA           ?= musa.py
 # The license is set via bananas.ini, do not supply a "custom" license.
@@ -373,6 +373,11 @@ ifdef OBG_FILENAME
 obg: $(OBG_FILENAME)
 
 %.obg: $(GFX_FILES) $(GRF_FILES) $(LNG_FILES) Makefile.vcs
+ifeq ($(GRFID),)
+	$(_E) "Cannot create obg files without grfid. Please install grfcodec, and try again. Aborting."
+	$(_V) false
+endif
+
 	$(_E) "[ASSEMBLING] $@"
 	@echo "[metadata]" > $@
 	@echo "name        = $(REPO_NAME)" >> $@
@@ -507,6 +512,11 @@ MD5_FILENAME       := $(DIR_NAME).md5
 MD5_SRC_FILENAME   := $(DIR_NAME).check.md5
 
 $(MD5_SRC_FILENAME) $(MD5_FILENAME): $(GFX_FILES) $(GRF_FILES)
+ifeq ($(GRFID),)
+	$(_E) "Cannot create md5 checks without grfid. Please install grfcodec, and try again. Aborting."
+	$(_V) false
+endif
+
 	$(_E) "[GRFID] $@"
 	$(_V) -rm -f $@
 	$(_V)for i in $(GRF_FILES); do printf "%-18s = %s\n" $$i `$(GRFID) $(GRFID_FLAGS) $$i` >> $@; done


### PR DESCRIPTION
Otherwise it barks out with weird errors about '-m' that nobody
is going to piece together. It now returns a proper error a user
can understand .. I hope :D