### PR TITLE
Fix: [GitHub Actions] make sure apt-database is in sync

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,8 +93,7 @@ jobs:
         sudo apt update
         sudo apt install -y gimp grfcodec --no-install-recommends
         python -m pip install --upgrade pip
-        # TODO -- If nml has a new release (higher than 0.4.5), this can just be 'pip install nml'
-        python -m pip install https://github.com/OpenTTD/nml/archive/master.zip
+        python -m pip install nml
 
     - if: steps.vars.outputs.skip == 'false'
       name: Build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,6 +90,7 @@ jobs:
       run: |
         set -e
 
+        sudo apt update
         sudo apt install -y gimp grfcodec --no-install-recommends
         python -m pip install --upgrade pip
         # TODO -- If nml has a new release (higher than 0.4.5), this can just be 'pip install nml'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -30,8 +30,7 @@ jobs:
         sudo apt update
         sudo apt install -y gimp grfcodec --no-install-recommends
         python -m pip install --upgrade pip
-        # TODO -- If nml has a new release (higher than 0.4.5), this can just be 'pip install nml'
-        python -m pip install https://github.com/OpenTTD/nml/archive/master.zip
+        python -m pip install nml
     - name: Build
       run: |
         set -e

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -27,6 +27,7 @@ jobs:
       run: |
         set -e
 
+        sudo apt update
         sudo apt install -y gimp grfcodec --no-install-recommends
         python -m pip install --upgrade pip
         # TODO -- If nml has a new release (higher than 0.4.5), this can just be 'pip install nml'


### PR DESCRIPTION
The OSes GitHub Actions run on, don't 'apt update' before becoming
available, and those OSes are not updated on a very regular base.
In result, hoping that a 'apt install' works is failing over time,
till the OS is updated again, and it slowly drifts into despair
again.

All this solved by an 'apt update' of course.