### PR TITLE
Fix: [Makefile] make sure installed filenames are as OpenTTD expects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -639,17 +639,19 @@ endif
 	$(_E) "[INSTALL] to $(INSTALL_DIR)"
 	$(_V) install -d $(INSTALL_DIR)
 	$(_V) install -m644 $(GRF_FILES) $(OBG_FILENAME) $(INSTALL_DIR)
+# OpenTTD is very picky about how these next few files are are named, so make
+# sure they have the correct name after installation
 ifndef DO_NOT_INSTALL_LICENSE
 	$(_V) install -d $(DOCDIR)
-	$(_V) install -m644 $(LICENSE_FILE) $(DOCDIR)
+	$(_V) install -m644 $(LICENSE_FILE) $(DOCDIR)/license.txt
 endif
 ifndef DO_NOT_INSTALL_CHANGELOG
 	$(_V) install -d $(DOCDIR)
-	$(_V) install -m644 $(CHANGELOG_FILE) $(DOCDIR)
+	$(_V) install -m644 $(CHANGELOG_FILE) $(DOCDIR)/changelog.txt
 endif
 ifndef DO_NOT_INSTALL_README
 	$(_V) install -d $(DOCDIR)
-	$(_V) install -m644 $(README_FILE) $(DOCDIR)
+	$(_V) install -m644 $(README_FILE) $(DOCDIR)/readme.txt
 endif
 
 


### PR DESCRIPTION
It looks for readme.txt, license.txt and changelog.txt by name. So no matter
how we call it in the repository, make sure it matches with the expectation
in the installed directory.

This fix was already applied for the tarball in PR #24, but that missed
the filenames used when installing into the filesystem directly. See
also issue #22.