### PR TITLE
Fix: [Actions] Specify AWS_DEFAULT_REGION in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -145,6 +145,7 @@ jobs:
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
 
     - if: steps.vars.outputs.dry-run == 'false' && steps.vars.outputs.skip == 'false'
       name: Trigger 'update CDN'


### PR DESCRIPTION
Fix publishing of builds, AWS_DEFAULT_REGION must now be specified