### PR TITLE
Some fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,38 +248,6 @@ OpenGFX is created by the following people (in reverse alphabetical order):
 | Ammler            | Marcel Gmür           |
 | 2006TTD           | Anthony Lam           |
 
-| Language              | Name                  |
-| --------------------- | --------------------- |
-| Afrikaans             | telanus               |
-| Catalan               | juanjo                |
-| Chinese (simplified)  | sui238X, xiangyigao   |
-| Chinese (traditional) | sui238X, xiangyigao   |
-| Croatian              | Voyager1              |
-| Czech                 | alfergen              |
-| Dutch                 | Alberth               |
-| English (US)          | Supercheese           |
-| Finnish               | juzza1, alluke        |
-| French                | arikover              |
-| German                | planetmaker, Czeczki  |
-| Hungarian             | zaza, Czeczki         |
-| Indonesian            | UseYourIllusion       |
-| Italian               | Voyager1              |
-| Japanese              | HawkEye1015           |
-| Korean                | Telk                  |
-| Latin                 | Supercheese           |
-| Lithuanian            | Stabilitronas         |
-| Luxembourgish         | Phreeze               |
-| Norwegian (bokmal)    | Trond, Leifbk         |
-| Polish                | TadeuszD              |
-| Portuguese            | vesgo                 |
-| Russian               | George                |
-| Scottish Gaelic       | GunChleoc             |
-| Serbian               | stravagante           |
-| Slovak                | Tenebrae              |
-| Spanish               | SilverSurferZzZ       |
-| Swedish               | Zuu, Pekkape01        |
-| Tamil                 | Aswn                  |
-
 - The monospaced characters are generated from the font Liberation Mono: https://www.redhat.com/promo/fonts/ created by Pravin Satpute and Caius Chance, released under GPL v2.
 
 Contact: `planetmaker@openttd.org` or on `irc.oftc.net/#openttd`

--- a/findversion.sh
+++ b/findversion.sh
@@ -57,7 +57,11 @@ ROOT_DIR=`pwd`
 # Determine if we are using a modified version
 # Assume the dir is not modified
 MODIFIED="0"
-if [ -d "$ROOT_DIR/.git" ] || [ -f "$ROOT_DIR/.git" ]; then
+if [ -f "$ROOT_DIR/.ottdrev" ]; then
+	# We are an exported source bundle
+	cat $ROOT_DIR/.ottdrev
+	exit
+elif [ -d "$ROOT_DIR/.git" ] || [ -f "$ROOT_DIR/.git" ]; then
 	# We are a git checkout
 	# Refresh the index to make sure file stat info is in sync, then look for modifications
 	git update-index --refresh >/dev/null
@@ -91,11 +95,6 @@ if [ -d "$ROOT_DIR/.git" ] || [ -f "$ROOT_DIR/.git" ]; then
 		ISTAG="0"
 		ISSTABLETAG="0"
 	fi
-
-elif [ -f "$ROOT_DIR/.ottdrev" ]; then
-	# We are an exported source bundle
-	cat $ROOT_DIR/.ottdrev
-	exit
 else
 	# We don't know
 	MODIFIED="1"

--- a/lang/english.lng
+++ b/lang/english.lng
@@ -2,4 +2,4 @@
 STR_GENERAL_DESC        :OpenGFX base graphics set for OpenTTD. Freely available under the terms of the GNU General Public License version 2. [{TITLE}]
 
 STR_GRF_NAME            :{TITLE}
-STR_GRF_DESCRIPTION     :{ORANGE}OpenGFX Base Graphics Set{BLACK}{}Brought to you by the OpenGFX team{}See readme for a list of contributors{}{BLACK}License: {SILVER}GPL v2+{}{BLACK}Website: {SILVER}http://dev.openttdcoop.org/projects/opengfx
+STR_GRF_DESCRIPTION     :{ORANGE}OpenGFX Base Graphics Set{BLACK}{}Brought to you by the OpenGFX team{}See readme for a list of contributors{}{BLACK}License: {SILVER}GPL v2+{}{BLACK}Website: {SILVER}https://github.com/OpenTTD/OpenGFX

--- a/lang/english.lng
+++ b/lang/english.lng
@@ -3,6 +3,3 @@ STR_GENERAL_DESC        :OpenGFX base graphics set for OpenTTD. Freely available
 
 STR_GRF_NAME            :{TITLE}
 STR_GRF_DESCRIPTION     :{ORANGE}OpenGFX Base Graphics Set{BLACK}{}Brought to you by the OpenGFX team{}See readme for a list of contributors{}{BLACK}License: {SILVER}GPL v2+{}{BLACK}Website: {SILVER}http://dev.openttdcoop.org/projects/opengfx
-
-STR_OPENTTD_VERSION     :1.2.0
-

--- a/sprites/extra/extra-header.pnml
+++ b/sprites/extra/extra-header.pnml
@@ -9,10 +9,10 @@ grf {
 
 if (ttd_platform == PLATFORM_OPENTTD) {
 	if (openttd_version < version_openttd(1, 2, 0, 23667)) {
-		error(FATAL, REQUIRES_OPENTTD, string(STR_OPENTTD_VERSION));
+		error(FATAL, REQUIRES_OPENTTD, "1.2.0");
 	}
 }
 
 if (ttd_platform != PLATFORM_OPENTTD) {
-	error(FATAL, REQUIRES_OPENTTD, string(STR_OPENTTD_VERSION));
+	error(FATAL, REQUIRES_OPENTTD, "1.2.0");
 }


### PR DESCRIPTION
Presume that's all correct anyway. Usual amount of testing done (none)

Partial fix for #61 - just hardcode the "1.2.0" string in the error message. I played around with getting rid of STR_GRF_NAME, but concluded you'd have to rip apart the build system to do so (which is terrifying, and probably needs doing at some point anyway). `{TITLE}` looks similar to a `{}` directive anyway, which most translators know not to touch.

Also updated the URL in the description