### PR TITLE
Fix: Update checkout-pull-request task

### DIFF
--- a/.github/workflows/commit-checker.yml
+++ b/.github/workflows/commit-checker.yml
@@ -17,7 +17,7 @@ jobs:
         fetch-depth: 4
 
     - name: Get pull-request commits
-      uses: OpenTTD/actions/checkout-pull-request@v4
+      uses: OpenTTD/actions/checkout-pull-request@v5
 
     - name: Check commits
       uses: OpenTTD/OpenTTD-git-hooks@main

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   testing:
     name: Testing
-    uses: OpenTTD/actions/.github/workflows/rw-entry-testing-baseset.yml@v4
+    uses: OpenTTD/actions/.github/workflows/rw-entry-testing-baseset.yml@v5
     with:
       apt-packages: gimp grfcodec
       name: opengfx


### PR DESCRIPTION
The checkout-pull-request task v4 relies on node 16 which has been deprecated. 
This causes a warning in the workflow run, which causes the "check-annotations" task to fail. 

v5 uses node 20, and is also used in the main OpenTTD repository. I am fairly confident this will resolve the workflow issue.