### PR TITLE
Makefile: update to GIMP3-compatible command-line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,8 +97,8 @@ GREP           ?= grep
 PYTHON         ?= python
 
 # Graphics processing
-GIMP           ?= $(shell command -v gimp)
-GIMP_FLAGS     ?= -n -i
+GIMP           ?= $(shell command -v gimp-console)
+GIMP_FLAGS     ?= -n -i --batch-interpreter=plug-in-script-fu-eval
 
 # NML
 NML            ?= nmlc


### PR DESCRIPTION
In particular:

 - Specify the batch script interpreter to use; GIMP3 provides multiple.

 - Use `gimp-console` instead of `gimp` to avoid a [non-interactive mode issue](https://gitlab.gnome.org/GNOME/gimp/-/issues/12042).

This doesn't solve all compatibility problems with GIMP3 yet; we also need to resolve the [removal](https://github.com/OpenTTD/OpenGFX/issues/94#issuecomment-2643514969) of a `gimp-image-get-active-layer` API function in GIMP3.

The changes* here are intended to be backwards-compatible to GIMP2 and have been tested GIMP2.10.34 on Debian stable (bookworm), and also with GIMP3.0.0 RC2 to build the OpenGFX 7.1 sources.

*NB: the `which` command has been [superseded](https://github.com/OpenTTD/OpenGFX/commit/0fda466271cae745f4d3d2b5fcf9b5f361a92ffd) by `command -v` since v7.1 in VCS, so a small patch adjustment is required if backporting.