### PR TITLE
Fix: [Makefile] python2 is long dead

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ DEFAULT_BRANCH_NAME ?= master
 # Text processing and scripting
 AWK            ?= awk
 GREP           ?= grep
-PYTHON         ?= python
+PYTHON         ?= python3
 
 # Graphics processing
 GIMP           ?= $(shell command -v gimp)


### PR DESCRIPTION
The `Makefile` uses Python to construct the NewGRF version.
The Python "script" is compatible with both Python2 and Python3.

The `Makefile` defaulted to Python2.  Now it's Python3.