### PR TITLE
 Script-Fu: Support GIMP3 in addition to GIMP2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,12 @@ PYTHON         ?= python3
 GIMP           ?= $(shell command -v gimp-console)
 GIMP_FLAGS     ?= -n -i --batch-interpreter=plug-in-script-fu-eval
 
+ifneq ($(findstring GNU Image Manipulation Program version 2., $(shell $(GIMP) --version)),)
+GIMP_SCRIPT     ?= $(SCRIPT_DIR)/gimpscript-v2
+else
+GIMP_SCRIPT     ?= $(SCRIPT_DIR)/gimpscript
+endif
+
 # NML
 NML            ?= nmlc
 NML_FLAGS      ?= -c
@@ -250,7 +256,7 @@ Makefile.gfx: $(GFX_SCRIPT_LIST_FILES) Makefile Makefile.config
 			for i in `cat $$j | grep "\([pP][cCnN][xXgG]\)" | grep -v "^#" | cut -d\  -f1 | sed "s/\.\([pP][cCnN][xXgG]\)//"`; do\
 				echo "$$i.scm: $$j" >> $@;\
 				echo "GFX_FILES += $$i.png" >> $@;\
-				cat $(SCRIPT_DIR)/gimpscript > $$i.scm.new;\
+				cat $(GIMP_SCRIPT) > $$i.scm.new;\
 				grep $$i.png $$j | sed -f $(SCRIPT_DIR)/gimp.sed >> $$i.scm.new;\
 				echo "(gimp-quit 0)" >> $$i.scm.new;\
 				cmp -s $$i.scm.new $$i.scm || cp $$i.scm.new $$i.scm;\

--- a/scripts/gimpscript
+++ b/scripts/gimpscript
@@ -5,8 +5,8 @@
 (define (script-fu-set-all-layers-invisible inImage inDrawable)
         (let*  (
                 (layers (gimp-image-get-layers inImage))
-                (num-layers (car layers))
-                (layer-array (cadr layers))
+                (layer-array (car layers))
+                (num-layers (vector-length layer-array))
                 (theLayer)
                )
 
@@ -14,9 +14,9 @@
 
         (while (> num-layers 0)
                 (set! num-layers (- num-layers 1))
-                (set! theLayer (aref layer-array num-layers))
-                (if (= (car (gimp-drawable-get-visible theLayer) ) TRUE)
-					(gimp-drawable-set-visible theLayer FALSE)
+                (set! theLayer (vector-ref layer-array num-layers))
+                (if (= (car (gimp-item-get-visible theLayer) ) TRUE)
+					(gimp-item-set-visible theLayer FALSE)
                 )
         )
 
@@ -46,10 +46,10 @@
 	(let*
 		(
 			(image (car (gimp-file-load RUN-NONINTERACTIVE inImageName inImageName)))
-			(visibleStuff (car (gimp-image-get-active-layer image)))
+			(visibleStuff (vector-ref (car (gimp-image-get-selected-layers image)) 0))
         	(layers (gimp-image-get-layers image))
-        	(num-layers (car layers))
-        	(layer-array (cadr layers))
+		(layer-array (car layers))
+		(num-layers (vector-length layer-array))
         	(thisLayer -1)
 			(thisNumLayers 0)
 			(theseLayers layers)
@@ -66,8 +66,8 @@
 		; iterate through all layers of the image
 		(while (> num-layers 0)
 			(set! num-layers (- num-layers 1))
-            (set! thisLayer (aref layer-array num-layers))
-			(set! thisLayerName (car (gimp-drawable-get-name thisLayer)))
+            (set! thisLayer (vector-ref layer-array num-layers))
+			(set! thisLayerName (car (gimp-item-get-name thisLayer)))
 			; (gimp-message (string-append "Image Layer-Name: " thisLayerName))
 
 			; iterate through all layer Names we shall use
@@ -75,7 +75,7 @@
 			(while (not (null? layerNames))
 				; if layerName matches this user supplied layername: make it visible
 				(if (string=? (car layerNames) thisLayerName)
-					(gimp-drawable-set-visible thisLayer TRUE)
+					(gimp-item-set-visible thisLayer TRUE)
 				)
 				(set! layerNames (cdr layerNames))
 			)
@@ -83,7 +83,7 @@
 
 		; Merge all visible layers into one layer which we then save to the given filename
 		(set! visibleStuff (car (gimp-image-merge-visible-layers image CLIP-TO-IMAGE)))
-		(file-png-save RUN-NONINTERACTIVE image visibleStuff outImageName outImageName 0 9 0 0 0 0 0)
+		(file-png-export #:run-mode RUN-NONINTERACTIVE #:image image #:file outImageName #:interlaced FALSE #:compression 9 #:bkgd FALSE #:offs FALSE #:phys FALSE #:time FALSE #:save-transparent FALSE)
 		(gimp-image-delete image)
 	)
 )

--- a/scripts/gimpscript-v2
+++ b/scripts/gimpscript-v2
@@ -1,0 +1,97 @@
+;----------script-fu-set-all-layers-invisible----------
+;procedure by Hevan53
+;------------------------------------------------------
+
+(define (script-fu-set-all-layers-invisible inImage inDrawable)
+        (let*  (
+                (layers (gimp-image-get-layers inImage))
+                (num-layers (car layers))
+                (layer-array (cadr layers))
+                (theLayer)
+               )
+
+        (gimp-image-undo-group-start inImage)
+
+        (while (> num-layers 0)
+                (set! num-layers (- num-layers 1))
+                (set! theLayer (aref layer-array num-layers))
+                (if (= (car (gimp-drawable-get-visible theLayer) ) TRUE)
+					(gimp-drawable-set-visible theLayer FALSE)
+                )
+        )
+
+        (gimp-image-undo-group-end inImage)
+        (gimp-displays-flush)
+
+        )
+)
+
+;--------------------save-layers-----------------------
+;procedure by planetmaker
+;
+; // List of source and target images followed by a list of layer names
+; // in the source image which will make up the target image.
+;
+; // Example:
+; // (save-layers "source-file-name" "target-file-name" '(layername1 layername2 layername3 ...))
+;------------------------------------------------------
+(define
+	(
+		save-layers
+
+		inImageName
+		outImageName
+		inLayerNames
+	)
+	(let*
+		(
+			(image (car (gimp-file-load RUN-NONINTERACTIVE inImageName inImageName)))
+			(visibleStuff (car (gimp-image-get-active-layer image)))
+        	(layers (gimp-image-get-layers image))
+        	(num-layers (car layers))
+        	(layer-array (cadr layers))
+        	(thisLayer -1)
+			(thisNumLayers 0)
+			(theseLayers layers)
+			(thisLayerName 0)
+
+			(layerNames inLayerNames)
+		)
+
+		; First make everything invisble
+		(script-fu-set-all-layers-invisible image image)
+
+		; Now make those layers visible which were asked to become visible
+
+		; iterate through all layers of the image
+		(while (> num-layers 0)
+			(set! num-layers (- num-layers 1))
+            (set! thisLayer (aref layer-array num-layers))
+			(set! thisLayerName (car (gimp-drawable-get-name thisLayer)))
+			; (gimp-message (string-append "Image Layer-Name: " thisLayerName))
+
+			; iterate through all layer Names we shall use
+			(set! layerNames inLayerNames)
+			(while (not (null? layerNames))
+				; if layerName matches this user supplied layername: make it visible
+				(if (string=? (car layerNames) thisLayerName)
+					(gimp-drawable-set-visible thisLayer TRUE)
+				)
+				(set! layerNames (cdr layerNames))
+			)
+		)
+
+		; Merge all visible layers into one layer which we then save to the given filename
+		(set! visibleStuff (car (gimp-image-merge-visible-layers image CLIP-TO-IMAGE)))
+		(file-png-save RUN-NONINTERACTIVE image visibleStuff outImageName outImageName 0 9 0 0 0 0 0)
+		(gimp-image-delete image)
+	)
+)
+
+
+; // ===================================================================
+; // List of source and target images followed by a list of layer names
+; // in the source image which will make up the target image.
+; // Example:
+; // (save-layers "source-file-name" "target-file-name" '(layername1 layername2 layername3 ...))
+; // ===================================================================


### PR DESCRIPTION
This PR extends #96 to re-add gimp2 compatibility as discussed in the comments there.

This includes:
 - the one commit from #96 verbatim, which changes the gimpscript file for v2 compatibility
 - a new commit re-adding the original gimpscript for v2, with the makefile selecting the right version

I tested this on Debian unstable with both gimp 2.10.34-1+deb12u2 from stable and gimp 3.0.0-2 from unstable.